### PR TITLE
サイトからDNSのIPを更新する部分を自動化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# 認証情報
+credential.js

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# DDNS自動Updater
+
+## やりたいこと
+
+家の鯖でDDNSするものの自動化
+
+## 現状
+
+IPを渡すと自動で変更してくれるところまで
+
+## つかいかた
+
+nodeでつかうものインストール
+```
+$ npm i
+```
+
+認証情報を ./credential.js に以下のフォーマットで作成
+```
+imodule.exports = {
+    'email': <ログインID>,
+    'password': <ログインPW>,
+    'ip': <変更後のIP>,
+    'domainId': <設定画面で使われているID>
+}
+```

--- a/index.js
+++ b/index.js
@@ -3,9 +3,12 @@ const moment = require('moment');
 // 認証情報を外部に置く
 const credential = require('./credential.js');
 
+// 認証情報の必要プロパティがあるかの確認
 if (
-    'string' !== typeof credential.email ||
-    'string' !== typeof credential.password
+        !credential.hasOwnProperty('email') ||
+        !credential.hasOwnProperty('password') ||
+        !credential.hasOwnProperty('ip') ||
+        !credential.hasOwnProperty('domainId')
     ){
     throw 'Rubbish. Credential info is empty or somethig wrong.';
 }

--- a/index.js
+++ b/index.js
@@ -51,6 +51,8 @@ if (
     await page.type('input[name=password]', credential.password)
     await page.click('input[name=action_user_login]')
     await page.waitForSelector('h1#logo')
+    // Login成功
+    await console.log(`[${moment().format("YYYY-MM-DD HH:mm:ssZ")}] Login Successful.`)
     
     // DNS設定ページに遷移
     await page.goto('https://secure.netowl.jp/star-domain/')
@@ -75,5 +77,5 @@ if (
     
     await browser.close()
     
-    console.log('やったぜ。 IP:' + credential.ip);
+    await console.log(`[${moment().format("YYYY-MM-DD HH:mm:ssZ")}] やったぜ。 IP: ${credential.ip}`)
 })()

--- a/index.js
+++ b/index.js
@@ -47,8 +47,8 @@ if (
     });
     // Login
     await page.goto('https://secure.netowl.jp/netowl/')
-    await page.type('input[name=mailaddress]', credential.email, { delay: 5 })
-    await page.type('input[name=password]', credential.password, { delay: 5 })
+    await page.type('input[name=mailaddress]', credential.email)
+    await page.type('input[name=password]', credential.password)
     await page.click('input[name=action_user_login]')
     await page.waitForSelector('h1#logo')
     

--- a/index.js
+++ b/index.js
@@ -1,0 +1,76 @@
+const puppeteer = require('puppeteer-core');
+const moment = require('moment');
+// 認証情報を外部に置く
+const credential = require('./credential.js');
+
+if (
+    'string' !== typeof credential.email ||
+    'string' !== typeof credential.password
+    ){
+    throw 'Rubbish. Credential info is empty or somethig wrong.';
+}
+
+(async () => {
+    //option
+    var option = {
+        headless : true,
+        executablePath: '/usr/bin/google-chrome-stable',
+        slowMo:1,
+        args: [
+            // ゲストセッションで操作する。
+            "--guest",
+            
+            // ウインドウサイズをデフォルトより大きめに。
+            '--window-size=1280,800',
+            
+            //最大化で表示
+            '--start-fullscreen',
+            
+            //情報バーの非表示
+            '--disable-infobars',
+            
+            //シークレットモード
+            '--incognito',
+        ],
+    }
+    
+    const browser = await puppeteer.launch(option)
+    const page = await browser.newPage()
+    
+    await page.setViewport({
+        width: 1280,
+        height: 700,
+        deviceScaleFactor: 1,
+    });
+    // Login
+    await page.goto('https://secure.netowl.jp/netowl/')
+    await page.type('input[name=mailaddress]', credential.email, { delay: 5 })
+    await page.type('input[name=password]', credential.password, { delay: 5 })
+    await page.click('input[name=action_user_login]')
+    await page.waitForSelector('h1#logo')
+    
+    // DNS設定ページに遷移
+    await page.goto('https://secure.netowl.jp/star-domain/')
+    await page.waitForSelector('h1#logo')
+    await page.click('input[name=action_user_detail_index]')
+    await page.waitForSelector('h1#logo')
+    await page.click('input[name=action_user_dns_index]')
+    await page.waitForSelector('h1#logo')
+    
+    // 当該ホスト名のIPを変更
+    await page.goto('https://secure.netowl.jp/star-domain/?action_user_dns_editpage_index=true')
+    await page.waitForSelector('h1#logo')
+    await page.focus('input[name="content[' + credential.domainId + ']"]')
+    await page.keyboard.down('Control')
+    await page.keyboard.down('KeyA')
+    await page.keyboard.up('Control')
+    await page.type('input[name="content[' + credential.domainId + ']"]', credential.ip)
+    
+    await page.click('input[name=action_user_dns_editpage_conf]') // 確認画面
+    await page.waitForSelector('h1#logo')
+    await page.click('input[name=action_user_dns_editpage_do]') // 確定する
+    
+    await browser.close()
+    
+    console.log('やったぜ。 IP:' + credential.ip);
+})()

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dns_updater",
+  "version": "1.0.0",
+  "description": "dns updater using puppeteer",
+  "main": "index.js",
+  "dependencies": {
+    "puppeteer-core": "^5.5.0"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "oratake",
+  "license": "ISC"
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "dns updater using puppeteer",
   "main": "index.js",
   "dependencies": {
+    "moment": "^2.29.1",
     "puppeteer-core": "^5.5.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
# Issue
- #1 

# やったこと
- puppeteerを使用してブラウザを自動操作
- プロジェクトのルートに認証情報をcredential.jsとしてオブジェクトを置くと自動で更新してくれる
(使用する場合の詳細はIssue)

# 備考
- 使用する前に `npm i` が必要
詳細をREADME内に追記済